### PR TITLE
fix: set width for search result container to 100%.

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -192,6 +192,7 @@ h2 {
 	min-height: 237px;
 	margin: 10px 0;
 	border-radius: 12px;
+	width: 100%;
 }
 
 .search-history-list {


### PR DESCRIPTION
fix: set width for search result container to 100%. inconsistent display on smaller devices